### PR TITLE
Trial to not redirect in case any errors

### DIFF
--- a/frontend/src/pages/Login/LoginPage.tsx
+++ b/frontend/src/pages/Login/LoginPage.tsx
@@ -179,7 +179,8 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
       isHash = pattern.test(window.location.hash);
     }
 
-    if ((authenticationConfig.strategy === AuthStrategy.openshift || authenticationConfig.strategy === AuthStrategy.openid) && !isHash && this.props.status === LoginStatus.loggedOut) {
+    if ((authenticationConfig.strategy === AuthStrategy.openshift|| authenticationConfig.strategy === AuthStrategy.openid)
+      && !isHash && this.props.status === LoginStatus.loggedOut && messages.length === 0 && (this.props.message ?? '').length === 0) {
       window.location.href = authenticationConfig.authorizationEndpoint!;
     }
 


### PR DESCRIPTION
Check if any messages are going to be shown and, if any, don't redirect automatically.

Unfortunately, redirection won't happen if session expires, because a message is shown to the user in this case. I don't think this is bad, so let's keeps things simple.