### PR TITLE
Do not fetch registry services when istiod is disabled.

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -174,6 +174,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 	var referenceChecker ReferenceChecker
 	istioReferences := models.IstioReferencesMap{}
 
+	var istioApiEnabled = config.Get().ExternalServices.Istio.IstioAPIEnabled
+
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
 	if _, err = in.businessLayer.Namespace.GetNamespace(ctx, namespace); err != nil {
@@ -188,11 +190,20 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 	errChan := make(chan error, 1)
 
 	// Get all the Istio objects from a Namespace and all gateways from every namespace
-	wg.Add(4)
+	wg.Add(3)
+
+	if istioApiEnabled {
+		wg.Add(1)
+	}
+
 	go in.fetchIstioConfigList(ctx, &istioConfigList, &mtlsDetails, &rbacDetails, namespace, errChan, &wg)
 	go in.fetchAllWorkloads(ctx, &workloadsPerNamespace, &namespaces, errChan, &wg)
 	go in.fetchNonLocalmTLSConfigs(&mtlsDetails, errChan, &wg)
-	go in.fetchRegistryServices(&registryServices, errChan, &wg)
+
+	if istioApiEnabled {
+		go in.fetchRegistryServices(&registryServices, errChan, &wg)
+	}
+
 	wg.Wait()
 
 	noServiceChecker := checkers.NoServiceChecker{Namespaces: namespaces, IstioConfigList: &istioConfigList, WorkloadsPerNamespace: workloadsPerNamespace, AuthorizationDetails: &rbacDetails, RegistryServices: registryServices, PolicyAllowAny: in.isPolicyAllowAny()}


### PR DESCRIPTION
Make consistency in validations between list and edit istio_configs.

The retrieving of non registry services when istiod is disabled will be in further PR.