### PR TITLE
ZTunnel tabs style

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -576,7 +576,7 @@ func (in *DashboardsService) BuildZtunnelDashboard(metrics models.MetricsMap) *m
 		Title:        "Ztunnel Metrics",
 		Aggregations: []models.Aggregation{},
 		Charts:       []models.Chart{},
-		Rows:         4,
+		Rows:         2,
 	}
 
 	ztunnelCharts := getZtunnelCharts()

--- a/frontend/src/components/Ambient/ZtunnelConfig.tsx
+++ b/frontend/src/components/Ambient/ZtunnelConfig.tsx
@@ -3,7 +3,7 @@ import { Workload } from 'types/Workload';
 import { Pod, ZtunnelConfigDump } from 'types/IstioObjects';
 import * as API from '../../services/Api';
 import * as AlertUtils from '../../utils/AlertUtils';
-import { Card, CardBody, Grid, GridItem, Tab, Tabs, TooltipPosition } from '@patternfly/react-core';
+import { Card, CardBody, Tab, Tabs, TooltipPosition } from '@patternfly/react-core';
 import { activeTab } from '../../components/Tab/Tabs';
 import { location, router } from '../../app/History';
 import {
@@ -20,6 +20,7 @@ import { ZtunnelWorkloadsTable } from './ZtunnelWorkloadsTable';
 import { t } from 'i18next';
 import { SortableTh } from '../Table/SimpleTable';
 import { ZtunnelMetrics } from './ZtunnelMetrics';
+import { RenderComponentScroll } from 'components/Nav/Page';
 
 const resources: string[] = ['services', 'workloads', 'metrics'];
 
@@ -34,19 +35,9 @@ type ZtunnelConfigProps = {
   workload: Workload;
 };
 
-const marginStyle = kialiStyle({
-  margin: '2em',
-  height: 'auto'
-});
-
 const iconStyle = kialiStyle({
   display: 'inline-block',
   alignSelf: 'center'
-});
-
-export const yoverflow = kialiStyle({
-  height: 'calc(100vh - 400px)',
-  overflow: 'auto'
 });
 
 export interface SortableCompareTh<T> extends SortableTh {
@@ -63,6 +54,7 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
   const [fetch, setFetch] = React.useState(true);
   const [activeKey, setActiveKey] = React.useState(ztunnelTabs.indexOf(activeTab(tabName, defaultTab)));
   const [resource, setResource] = React.useState(activeTab(tabName, defaultTab));
+  const [tabHeight, setTabHeight] = React.useState<number>(700);
 
   const prevResource = React.createRef();
   const prevPod = React.createRef();
@@ -197,6 +189,7 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
             lastRefreshAt={props.lastRefreshAt}
             namespace={props.namespace}
             cluster={props.workload.cluster ? props.workload.cluster : ''}
+            dashboardHeight={tabHeight - 200}
           />
         </CardBody>
       </Card>
@@ -205,21 +198,17 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
   tabs.push(metricsTab);
 
   return (
-    <div className={marginStyle}>
-      <Grid>
-        <GridItem span={12}>
-          <Tabs
-            id="ztunnel-details"
-            className={subTabStyle}
-            activeKey={activeKey}
-            onSelect={ztunnelHandleTabClick}
-            mountOnEnter={true}
-            unmountOnExit={true}
-          >
-            {tabs}
-          </Tabs>
-        </GridItem>
-      </Grid>
-    </div>
+    <RenderComponentScroll onResize={height => setTabHeight(height)}>
+      <Tabs
+        id="ztunnel-details"
+        className={subTabStyle}
+        activeKey={activeKey}
+        onSelect={ztunnelHandleTabClick}
+        mountOnEnter={true}
+        unmountOnExit={true}
+      >
+        {tabs}
+      </Tabs>
+    </RenderComponentScroll>
   );
 };

--- a/frontend/src/components/Ambient/ZtunnelMetrics.tsx
+++ b/frontend/src/components/Ambient/ZtunnelMetrics.tsx
@@ -15,25 +15,19 @@ import { Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import { MetricsObjectTypes } from '../../types/Metrics';
 import { GrafanaInfo } from '../../types/GrafanaInfo';
 import { MessageType } from '../../types/MessageCenter';
-import { kialiStyle } from '../../styles/StyleUtils';
 
 type ZtunnelMetricsProps = {
   cluster: string;
+  dashboardHeight: number;
   lastRefreshAt: TimeInMilliseconds;
   namespace: string;
   rangeDuration: TimeRange;
 };
 
-const fullHeightStyle = kialiStyle({
-  height: 'calc(100vh - 380px)',
-  overflowY: 'auto'
-});
-
 export const ZtunnelMetrics: React.FC<ZtunnelMetricsProps> = (props: ZtunnelMetricsProps) => {
   const urlParams = new URLSearchParams(location.getSearch());
   const expandedChart = urlParams.get('expand') ?? undefined;
   const toolbarRef = React.createRef<HTMLDivElement>();
-  const tabHeight = 600;
   const [metrics, setMetrics] = React.useState<DashboardModel>();
   const [grafanaLinks, setGrafanaLinks] = React.useState<GrafanaInfo>();
   const rateParams = computePrometheusRateParams(
@@ -51,7 +45,7 @@ export const ZtunnelMetrics: React.FC<ZtunnelMetricsProps> = (props: ZtunnelMetr
     step: rateParams.step
   };
 
-  const fetchMetrics = (): Promise<void> => {
+  const fetchMetrics = async (): Promise<void> => {
     MetricsHelper.timeRangeToOptions(props.rangeDuration, options);
     let opts = { ...options };
 
@@ -93,17 +87,12 @@ export const ZtunnelMetrics: React.FC<ZtunnelMetricsProps> = (props: ZtunnelMetr
   }, []);
 
   const settings = MetricsHelper.retrieveMetricsSettings(200);
-  const [dashboardHeight, setDashboardHeight] = React.useState<number>(1000);
-
   const expandHandler = (expandedChart?: string): void => {
     const urlParams = new URLSearchParams(location.getSearch());
     urlParams.delete('expand');
 
     if (expandedChart) {
-      setDashboardHeight(tabHeight);
       urlParams.set('expand', expandedChart);
-    } else {
-      setDashboardHeight(1000);
     }
 
     router.navigate(`${location.getPathname()}?${urlParams.toString()}`);
@@ -115,7 +104,7 @@ export const ZtunnelMetrics: React.FC<ZtunnelMetricsProps> = (props: ZtunnelMetr
         <div ref={toolbarRef}>
           <Toolbar style={{ padding: 0, marginBottom: '1.25rem' }}>
             <ToolbarGroup>
-              <ToolbarItem style={{ marginLeft: 'auto', paddingRight: '20px' }}>
+              <ToolbarItem style={{ marginLeft: 'auto', paddingRight: '1.25rem' }}>
                 <GrafanaLinks
                   links={grafanaLinks?.externalLinks}
                   namespace={props.namespace}
@@ -128,17 +117,15 @@ export const ZtunnelMetrics: React.FC<ZtunnelMetricsProps> = (props: ZtunnelMetr
         </div>
       )}
       {metrics && (
-        <div className={fullHeightStyle}>
-          <Dashboard
-            dashboard={metrics}
-            labelValues={MetricsHelper.convertAsPromLabels(settings.labelsSettings)}
-            maximizedChart={expandedChart}
-            expandHandler={expandHandler}
-            labelPrettifier={MetricsHelper.prettyLabelValues}
-            showSpans={false}
-            dashboardHeight={dashboardHeight}
-          />
-        </div>
+        <Dashboard
+          dashboard={metrics}
+          labelValues={MetricsHelper.convertAsPromLabels(settings.labelsSettings)}
+          maximizedChart={expandedChart}
+          expandHandler={expandHandler}
+          labelPrettifier={MetricsHelper.prettyLabelValues}
+          showSpans={false}
+          dashboardHeight={props.dashboardHeight}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/Ambient/ZtunnelServicesTable.tsx
+++ b/frontend/src/components/Ambient/ZtunnelServicesTable.tsx
@@ -5,7 +5,7 @@ import { SimpleTable } from '../Table/SimpleTable';
 import { EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
 import { kialiStyle } from '../../styles/StyleUtils';
 import { t } from 'i18next';
-import { SortableCompareTh, yoverflow } from './ZtunnelConfig';
+import { SortableCompareTh } from './ZtunnelConfig';
 
 type ZtunnelServicesProps = {
   config?: ZtunnelService[];
@@ -101,17 +101,14 @@ export const ZtunnelServicesTable: React.FC<ZtunnelServicesProps> = (props: Ztun
   );
 
   return (
-    <div className={yoverflow}>
-      <SimpleTable
-        label={t('Ztunnel services config')}
-        columns={columns}
-        rows={rows}
-        variant={TableVariant.compact}
-        emptyState={noServicesConfig}
-        sortBy={sort}
-        onSort={onSort}
-        theadStyle={{ position: 'sticky', top: 0, backgroundColor: 'white', zIndex: 1 }}
-      />
-    </div>
+    <SimpleTable
+      label={t('Ztunnel services config')}
+      columns={columns}
+      rows={rows}
+      variant={TableVariant.compact}
+      emptyState={noServicesConfig}
+      sortBy={sort}
+      onSort={onSort}
+    />
   );
 };

--- a/frontend/src/components/Ambient/ZtunnelWorkloadsTable.tsx
+++ b/frontend/src/components/Ambient/ZtunnelWorkloadsTable.tsx
@@ -5,7 +5,7 @@ import { EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react
 import { emtpytStyle } from './ZtunnelServicesTable';
 import { SimpleTable } from '../Table/SimpleTable';
 import { t } from 'i18next';
-import { SortableCompareTh, yoverflow } from './ZtunnelConfig';
+import { SortableCompareTh } from './ZtunnelConfig';
 
 type ZtunnelWorkloadsProps = {
   config?: ZtunnelWorkload[];
@@ -88,17 +88,14 @@ export const ZtunnelWorkloadsTable: React.FC<ZtunnelWorkloadsProps> = (props: Zt
   );
 
   return (
-    <div className={yoverflow}>
-      <SimpleTable
-        label={t('Ztunnel workloads config')}
-        columns={columns}
-        rows={rows}
-        theadStyle={{ position: 'sticky', top: 0, backgroundColor: 'white', zIndex: 1 }}
-        variant={TableVariant.compact}
-        emptyState={noWorkloadsConfig}
-        sortBy={sort}
-        onSort={onSort}
-      />
-    </div>
+    <SimpleTable
+      label={t('Ztunnel workloads config')}
+      columns={columns}
+      rows={rows}
+      variant={TableVariant.compact}
+      emptyState={noWorkloadsConfig}
+      sortBy={sort}
+      onSort={onSort}
+    />
   );
 };

--- a/frontend/src/components/Envoy/EnvoyDetails.tsx
+++ b/frontend/src/components/Envoy/EnvoyDetails.tsx
@@ -7,18 +7,7 @@ import { Workload } from 'types/Workload';
 import { EnvoyProxyDump, Pod } from 'types/IstioObjects';
 import * as API from '../../services/Api';
 import * as AlertUtils from '../../utils/AlertUtils';
-import {
-  Button,
-  ButtonVariant,
-  Card,
-  CardBody,
-  Grid,
-  GridItem,
-  Tab,
-  Tabs,
-  Tooltip,
-  TooltipPosition
-} from '@patternfly/react-core';
+import { Button, ButtonVariant, Card, CardBody, Tab, Tabs, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { SummaryTableBuilder } from './tables/BaseTable';
 import { Namespace } from 'types/Namespace';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -379,20 +368,16 @@ class EnvoyDetailsComponent extends React.Component<EnvoyDetailsProps, EnvoyDeta
 
     return (
       <RenderComponentScroll onResize={height => this.setState({ tabHeight: height })}>
-        <Grid>
-          <GridItem span={12}>
-            <Tabs
-              id="envoy-details"
-              className={subTabStyle}
-              activeKey={this.state.activeKey}
-              onSelect={this.envoyHandleTabClick}
-              mountOnEnter={true}
-              unmountOnExit={true}
-            >
-              {tabs}
-            </Tabs>
-          </GridItem>
-        </Grid>
+        <Tabs
+          id="envoy-details"
+          className={subTabStyle}
+          activeKey={this.state.activeKey}
+          onSelect={this.envoyHandleTabClick}
+          mountOnEnter={true}
+          unmountOnExit={true}
+        >
+          {tabs}
+        </Tabs>
       </RenderComponentScroll>
     );
   }

--- a/frontend/src/components/Nav/Page/RenderComponentScroll.tsx
+++ b/frontend/src/components/Nav/Page/RenderComponentScroll.tsx
@@ -20,7 +20,7 @@ const EMBEDDED_PADDING = 42;
 const globalScrollbar = process.env.GLOBAL_SCROLLBAR ?? 'false';
 
 const componentStyle = kialiStyle({
-  padding: '20px'
+  padding: '1.25rem'
 });
 
 interface Props {


### PR DESCRIPTION
### Describe the change

- Change the number of dashboard rows to show
- ZTunnel tab is very similar to the Envoy tab, so it should be consistent in the look and feel:
  - Use RenderComponentScroll component
  - Remove Grid to make it simpler (no look and feel difference) 
  - Use the same global scrollbar as Envoy tab. It's fine to have a table with sticky headers, but it should be applied to all similar tables. We could discuss with Foday what is the best approach.