### PR TITLE
Add comprehensive Istio list evaluation test

### DIFF
--- a/tests/evals/tasks/istio-list-comprehensive/cleanup.sh
+++ b/tests/evals/tasks/istio-list-comprehensive/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Delete all resources created by this test
+kubectl delete virtualservices,destinationrules,gateways,serviceentries \
+  -n bookinfo \
+  -l gevals.kiali.io/test=gevals-testing \
+  --ignore-not-found=true
+
+echo "Cleaned up comprehensive istio configuration test resources"

--- a/tests/evals/tasks/istio-list-comprehensive/istio-list-comprehensive.yaml
+++ b/tests/evals/tasks/istio-list-comprehensive/istio-list-comprehensive.yaml
@@ -1,0 +1,33 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kiali
+  name: "List Comprehensive Istio Configuration"
+  category: "Configuration Management"
+  description: "Lists multiple Istio resources across different types to validate token efficiency with larger datasets. This test validates that the grouped output format provides better token efficiency at scale."
+  difficulty: easy
+spec:
+  cleanup:
+  - script:
+      file: ./cleanup.sh
+      timeout: 120s
+  prompt:
+    inline: |
+      List all Istio configuration resources in the 'bookinfo' namespace.
+      Provide a summary of how many VirtualServices, DestinationRules, Gateways, and ServiceEntries you found.
+      Also report if any of these resources have validation errors.
+  requires:
+  - extension: kubernetes
+    as: k8s
+  setup:
+  - script:
+      file: ./setup.sh
+      timeout: 120s
+  verify:
+  - llmJudge:
+      contains: "VirtualService"
+  - llmJudge:
+      contains: "DestinationRule"
+  - llmJudge:
+      contains: "Gateway"

--- a/tests/evals/tasks/istio-list-comprehensive/setup.sh
+++ b/tests/evals/tasks/istio-list-comprehensive/setup.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create multiple VirtualServices (10)
+for i in {1..10}; do
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: service-${i}-vs
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  hosts:
+  - "service-${i}.bookinfo.svc.cluster.local"
+  http:
+  - route:
+    - destination:
+        host: service-${i}
+        port:
+          number: 8080
+EOF
+done
+
+# Create multiple DestinationRules (10)
+for i in {1..10}; do
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: service-${i}-dr
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  host: service-${i}.bookinfo.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        http1MaxPendingRequests: 50
+        http2MaxRequests: 100
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+EOF
+done
+
+# Create multiple Gateways (5)
+for i in {1..5}; do
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: gateway-${i}
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "service-${i}.example.com"
+EOF
+done
+
+# Create multiple ServiceEntries (5)
+for i in {1..5}; do
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: external-service-${i}
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  hosts:
+  - external-${i}.example.com
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  location: MESH_EXTERNAL
+  resolution: DNS
+EOF
+done
+
+# Create one VirtualService with intentional validation error
+cat <<'EOF' | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: invalid-vs
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  hosts:
+  - "invalid-service"
+  gateways:
+  - non-existent-gateway
+  http:
+  - route:
+    - destination:
+        host: invalid-service
+        subset: non-existent-subset
+EOF
+
+echo "Created 10 VirtualServices, 10 DestinationRules, 5 Gateways, and 5 ServiceEntries in bookinfo namespace"


### PR DESCRIPTION
## Summary

Adds a new MCP evaluation test `istio-list-comprehensive` that creates a larger set of Istio resources (31 total) to validate token efficiency at scale.

## Motivation

Current evaluation tests (`istio-list`, `istio-list-destination-rules`) create only 1-3 Istio resources, which is insufficient to demonstrate the token savings of grouped output formats when listing many resources.

This test establishes a baseline that will show the true benefit of the namespace→GVK→{valid,invalid} grouped format vs the flat array format.

## What's Created

The test creates in the `bookinfo` namespace:
- **10 VirtualServices** (service-1-vs through service-10-vs)
- **10 DestinationRules** (service-1-dr through service-10-dr) with v1/v2 subsets
- **5 Gateways** (gateway-1 through gateway-5)
- **5 ServiceEntries** (external-service-1 through external-service-5)
- **1 Invalid VirtualService** (`invalid-vs`) to test validation error detection

**Total: 31 Istio configuration objects**

## Expected Impact

With 31 resources, the grouped format should show:
- **~60-75% token reduction** in the `istio list` output compared to flat array
- Demonstrates scalability benefits of deduplicating namespace/group/version/kind metadata

## Test Details

- **File**: `tests/evals/tasks/istio-list-comprehensive/istio-list-comprehensive.yaml`
- **Setup**: Creates resources via kubectl apply
- **Cleanup**: Deletes all resources with label `gevals.kiali.io/test=gevals-testing`
- **Verification**: Checks that VirtualService, DestinationRule, and Gateway are mentioned in response

## Next Steps

After merge:
1. CI will run mcpchecker and establish new baseline
2. PR #9945 (Istio list optimization) will show significant token savings on this test
3. Validates that grouped format scales better with realistic resource counts

---
🤖 Generated with Claude Code