### PR TITLE
Review suggestions for #9989: Ambient MCP fixes

### DIFF
--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
@@ -467,13 +467,13 @@ func analyzeVirtualService(vs *networking_v1.VirtualService, nsStatus NamespaceA
 		Rules:      countVirtualServiceRules(&vs.Spec),
 	}
 
-	isHTTPortTLS := len(vs.Spec.Http) > 0 || len(vs.Spec.Tls) > 0
+	hasHTTPOrTLS := len(vs.Spec.Http) > 0 || len(vs.Spec.Tls) > 0
 
-	if isHTTPortTLS && appliesToMeshTraffic(vs.Spec.Gateways) {
+	if hasHTTPOrTLS && appliesToMeshTraffic(vs.Spec.Gateways) {
 		analyzed.Layer = "L7"
 		analyzed.Reason = "VirtualService provides HTTP/TLS routing for mesh traffic (requires waypoint)"
 		analyzed.Warning = ambientNoWaypointWarning(nsStatus, "This VirtualService will NOT work.")
-	} else if isHTTPortTLS {
+	} else if hasHTTPOrTLS {
 		analyzed.Layer = "L7"
 		analyzed.Reason = "VirtualService provides HTTP/TLS routing via ingress/egress Gateway (no waypoint needed)"
 	} else {

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies_test.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies_test.go
@@ -1,14 +1,23 @@
 package analyze_ambient_policies
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	networking_v1_api "istio.io/api/networking/v1"
 	security_v1_api "istio.io/api/security/v1"
 	telemetry_v1_api "istio.io/api/telemetry/v1"
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kiali/kiali/ai/mcputil"
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
 func TestIsL7Policy_HTTPMethods(t *testing.T) {
@@ -445,4 +454,74 @@ func TestAmbientNoWaypointWarning_AmbientNoWaypoint(t *testing.T) {
 	warning := ambientNoWaypointWarning(nsStatus, "Things will break.")
 	assert.Contains(t, warning, "NO waypoint")
 	assert.Contains(t, warning, "Things will break.")
+}
+
+func setupExecuteTest(t *testing.T, objs ...runtime.Object) (*mcputil.KialiInterface, *config.Config) {
+	t.Helper()
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "east"
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(objs...)
+	layer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
+	r := httptest.NewRequest(http.MethodPost, "/api/chat/mcp/analyze_ambient_policies", nil)
+	r.Header.Set("Kiali-User", "test-user")
+	return &mcputil.KialiInterface{
+		Request:       r,
+		BusinessLayer: layer,
+		Conf:          conf,
+	}, conf
+}
+
+func TestExecute_BothNamespaceAndNamespaces_ReturnsBadRequest(t *testing.T) {
+	ki, _ := setupExecuteTest(t,
+		kubetest.FakeNamespaceWithLabels("ambient-ns", map[string]string{
+			config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+		}),
+	)
+
+	result, status := Execute(ki, map[string]interface{}{
+		"namespace":  "ambient-ns",
+		"namespaces": []interface{}{"ambient-ns"},
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, result.(string), "cannot specify both")
+}
+
+func TestExecute_AutoDiscoverAmbientNamespaces(t *testing.T) {
+	ki, _ := setupExecuteTest(t,
+		kubetest.FakeNamespaceWithLabels("ambient-ns", map[string]string{
+			config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+		}),
+		kubetest.FakeNamespace("default"),
+	)
+
+	result, status := Execute(ki, map[string]interface{}{})
+	assert.Equal(t, http.StatusOK, status)
+
+	resp, ok := result.(PolicyAnalysisResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Namespaces, 1)
+	assert.Equal(t, "ambient-ns", resp.Namespaces[0].NamespaceStatus.Name)
+}
+
+func TestExecute_InvalidNamespace_RecordsPerNamespaceError(t *testing.T) {
+	ki, _ := setupExecuteTest(t,
+		kubetest.FakeNamespaceWithLabels("ambient-ns", map[string]string{
+			config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+		}),
+	)
+
+	result, status := Execute(ki, map[string]interface{}{
+		"namespaces": []interface{}{"ambient-ns", "missing-ns"},
+	})
+	assert.Equal(t, http.StatusOK, status)
+
+	resp, ok := result.(PolicyAnalysisResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Namespaces, 2)
+	assert.Equal(t, "ambient-ns", resp.Namespaces[0].NamespaceStatus.Name)
+	assert.NotContains(t, resp.Namespaces[0].Summary, "Error:")
+	assert.Equal(t, "missing-ns", resp.Namespaces[1].NamespaceStatus.Name)
+	assert.Contains(t, resp.Namespaces[1].Summary, "Error:")
 }

--- a/ai/mcp/list_or_get_resources/ambient_test.go
+++ b/ai/mcp/list_or_get_resources/ambient_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -93,4 +94,52 @@ func TestExtractAmbientNetworking_NilDump(t *testing.T) {
 
 	result := extractAmbientNetworking(wl, nil)
 	assert.Nil(t, result)
+}
+
+func TestExtractAmbientNetworking_FQDNServiceRefs(t *testing.T) {
+	wl := &models.Workload{
+		WorkloadListItem: models.WorkloadListItem{
+			Name:      "details-v1",
+			Namespace: "bookinfo",
+		},
+	}
+
+	dump := &kubernetes.ZtunnelConfigDump{
+		Workloads: []kubernetes.Workload{
+			{
+				WorkloadName: "details-v1",
+				Namespace:    "bookinfo",
+				Protocol:     "HBONE",
+				Services: []string{
+					"bookinfo/details.bookinfo.svc.cluster.local",
+				},
+			},
+		},
+		Services: []kubernetes.Service{
+			{
+				Hostname:  "details.bookinfo.svc.cluster.local",
+				Name:      "details",
+				Namespace: "bookinfo",
+				Vips:      []string{"10.96.0.1"},
+			},
+		},
+	}
+
+	result := extractAmbientNetworking(wl, dump)
+	require.NotNil(t, result)
+	assert.True(t, result.Captured)
+	require.Len(t, result.CapturedServices, 1)
+	assert.Equal(t, "details", result.CapturedServices[0].Name)
+}
+
+func TestZtunnelReferencesService(t *testing.T) {
+	svc := &kubernetes.Service{
+		Hostname:  "details.bookinfo.svc.cluster.local",
+		Name:      "details",
+		Namespace: "bookinfo",
+	}
+
+	assert.True(t, ztunnelReferencesService([]string{"bookinfo/details.bookinfo.svc.cluster.local"}, svc))
+	assert.True(t, ztunnelReferencesService([]string{"details"}, svc))
+	assert.False(t, ztunnelReferencesService([]string{"bookinfo/reviews.bookinfo.svc.cluster.local"}, svc))
 }

--- a/ai/mcp/list_or_get_resources/transforms.go
+++ b/ai/mcp/list_or_get_resources/transforms.go
@@ -2,7 +2,6 @@ package list_or_get_resources
 
 import (
 	"fmt"
-	"slices"
 	"sort"
 	"strings"
 
@@ -814,8 +813,8 @@ func extractAmbientNetworking(wl *models.Workload, dump *kubernetes.ZtunnelConfi
 	var capturedServices []ZtunnelServiceInfo
 	for i := range dump.Services {
 		svc := &dump.Services[i]
-		// Check if this service references the workload
-		if slices.Contains(ztunnelWorkload.Services, svc.Name) {
+		// ztunnel workload service refs use "namespace/hostname" (see kubernetes/testdata/ztunnel-config.json).
+		if ztunnelReferencesService(ztunnelWorkload.Services, svc) {
 			waypointDest := ""
 			if svc.Waypoint.Destination != "" {
 				waypointDest = svc.Waypoint.Destination
@@ -838,4 +837,25 @@ func extractAmbientNetworking(wl *models.Workload, dump *kubernetes.ZtunnelConfi
 		TrustDomain:      ztunnelWorkload.TrustDomain,
 		CapturedServices: capturedServices,
 	}
+}
+
+// ztunnelReferencesService reports whether a ztunnel workload service entry references the given service.
+// Workload.Services entries use "namespace/hostname" (e.g. "bookinfo/details.bookinfo.svc.cluster.local").
+func ztunnelReferencesService(workloadServices []string, svc *kubernetes.Service) bool {
+	if len(workloadServices) == 0 {
+		return false
+	}
+	fqdnRef := ""
+	if svc.Hostname != "" {
+		fqdnRef = fmt.Sprintf("%s/%s", svc.Namespace, svc.Hostname)
+	}
+	for _, ref := range workloadServices {
+		if ref == svc.Name || ref == svc.Hostname {
+			return true
+		}
+		if fqdnRef != "" && ref == fqdnRef {
+			return true
+		}
+	}
+	return false
 }

--- a/ai/mcp/tools/list_or_get_resources.yaml
+++ b/ai/mcp/tools/list_or_get_resources.yaml
@@ -5,16 +5,19 @@
     type: "object"
     required: ["resourceType"]
     properties:
+      clusterName:
+        type: "string"
+        description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig."
+      namespace:
+        type: "string"
+        description: "Optional alias for 'namespaces' when querying a single namespace (e.g., 'bookinfo'). Cannot be combined with a comma-separated 'namespaces' value."
+      namespaces:
+        type: "string"
+        description: "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces. The singular alias 'namespace' is also accepted for a single namespace value."
+      resourceName:
+        type: "string"
+        description: "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource."
       resourceType:
         type: "string"
         description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically."
         enum: ["service", "workload", "app", "namespace", "argoapp"]
-      namespaces:
-        type: "string"
-        description: "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces."
-      resourceName:
-        type: "string"
-        description: "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource."
-      clusterName:
-        type: "string"
-        description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig."

--- a/ai/mcputil/args.go
+++ b/ai/mcputil/args.go
@@ -135,9 +135,3 @@ func GetStringOrDefault(args map[string]interface{}, defaultValue string, keys .
 	}
 	return defaultValue
 }
-
-// GetBoolArg returns the boolean value for the first present key in args.
-// Alias for AsBoolFromArgs for consistency with GetStringArg, GetTimeArg.
-func GetBoolArg(args map[string]interface{}, keys ...string) bool {
-	return AsBoolFromArgs(args, keys...)
-}

--- a/ai/providers/anthropic/anthropic_tools_test.go
+++ b/ai/providers/anthropic/anthropic_tools_test.go
@@ -397,22 +397,26 @@ func TestConvertToolToAnthropic_FromToolDefinition_ListOrGetResources(t *testing
 			Description: param.NewOpt("Fetches a list of resources OR retrieves detailed data for a specific resource. If 'resourceName' is omitted, it returns a list. If 'resourceName' is provided, it returns details for that specific resource."),
 			InputSchema: anthropic.ToolInputSchemaParam{
 				Properties: map[string]interface{}{
-					"resourceType": map[string]interface{}{
+					"clusterName": map[string]interface{}{
 						"type":        "string",
-						"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
-						"enum":        []interface{}{"service", "workload", "app", "namespace", "argoapp"},
+						"description": "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
+					},
+					"namespace": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional alias for 'namespaces' when querying a single namespace (e.g., 'bookinfo'). Cannot be combined with a comma-separated 'namespaces' value.",
 					},
 					"namespaces": map[string]interface{}{
 						"type":        "string",
-						"description": "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces.",
+						"description": "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces. The singular alias 'namespace' is also accepted for a single namespace value.",
 					},
 					"resourceName": map[string]interface{}{
 						"type":        "string",
 						"description": "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource.",
 					},
-					"clusterName": map[string]interface{}{
+					"resourceType": map[string]interface{}{
 						"type":        "string",
-						"description": "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
+						"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
+						"enum":        []interface{}{"service", "workload", "app", "namespace", "argoapp"},
 					},
 				},
 				Required: []string{"resourceType"},

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -329,22 +329,26 @@ func TestConvertToolToGoogle_FromToolDefinition_ListOrGetResources(t *testing.T)
 	expected := &genai.Schema{
 		Type: genai.TypeObject,
 		Properties: map[string]*genai.Schema{
-			"resourceType": {
+			"clusterName": {
 				Type:        genai.TypeString,
-				Description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
-				Enum:        []string{"service", "workload", "app", "namespace", "argoapp"},
+				Description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
+			},
+			"namespace": {
+				Type:        genai.TypeString,
+				Description: "Optional alias for 'namespaces' when querying a single namespace (e.g., 'bookinfo'). Cannot be combined with a comma-separated 'namespaces' value.",
 			},
 			"namespaces": {
 				Type:        genai.TypeString,
-				Description: "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces.",
+				Description: "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces. The singular alias 'namespace' is also accepted for a single namespace value.",
 			},
 			"resourceName": {
 				Type:        genai.TypeString,
 				Description: "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource.",
 			},
-			"clusterName": {
+			"resourceType": {
 				Type:        genai.TypeString,
-				Description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
+				Description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
+				Enum:        []string{"service", "workload", "app", "namespace", "argoapp"},
 			},
 		},
 		Required: []string{"resourceType"},

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -446,6 +446,22 @@ func TestConvertToolToOpenAI_FromToolDefinition_ListOrGetResources(t *testing.T)
 						"resourceType",
 					},
 					"properties": map[string]interface{}{
+						"clusterName": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
+						},
+						"namespace": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional alias for 'namespaces' when querying a single namespace (e.g., 'bookinfo'). Cannot be combined with a comma-separated 'namespaces' value.",
+						},
+						"namespaces": map[string]interface{}{
+							"type":        "string",
+							"description": "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces. The singular alias 'namespace' is also accepted for a single namespace value.",
+						},
+						"resourceName": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource.",
+						},
 						"resourceType": map[string]interface{}{
 							"type":        "string",
 							"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
@@ -456,18 +472,6 @@ func TestConvertToolToOpenAI_FromToolDefinition_ListOrGetResources(t *testing.T)
 								"namespace",
 								"argoapp",
 							},
-						},
-						"namespaces": map[string]interface{}{
-							"type":        "string",
-							"description": "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces.",
-						},
-						"resourceName": map[string]interface{}{
-							"type":        "string",
-							"description": "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource.",
-						},
-						"clusterName": map[string]interface{}{
-							"type":        "string",
-							"description": "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
 						},
 					},
 				},

--- a/handlers/ai.go
+++ b/handlers/ai.go
@@ -109,12 +109,7 @@ func ChatMCP(
 		}
 		// Gate Ambient-specific tools before building the full interface, matching the tracing/metrics pattern above.
 		if mcp.IsAmbientTool(toolName) {
-			saClients := clientFactory.GetSAClients()
-			accessibleClusters := make([]string, 0, len(saClients))
-			for clusterName := range saClients {
-				accessibleClusters = append(accessibleClusters, clusterName)
-			}
-			if !kialiCache.IsAmbientEnabledInAnyCluster(accessibleClusters) {
+			if !kialiCache.IsAmbientEnabledInAnyCluster(accessibleClusterNames(clientFactory)) {
 				RespondWithError(w, http.StatusNotFound,
 					fmt.Sprintf("Tool '%s' is not available when Ambient Mesh is not enabled in any cluster", toolName))
 				return
@@ -134,6 +129,16 @@ func ChatMCP(
 	}
 }
 
+// accessibleClusterNames returns cluster names reachable via the client factory's service-account clients.
+func accessibleClusterNames(clientFactory kubernetes.ClientFactory) []string {
+	saClients := clientFactory.GetSAClients()
+	names := make([]string, 0, len(saClients))
+	for clusterName := range saClients {
+		names = append(names, clusterName)
+	}
+	return names
+}
+
 func ChatPrompts(conf *config.Config, kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !conf.ChatAI.Enabled {
@@ -141,13 +146,7 @@ func ChatPrompts(conf *config.Config, kialiCache cache.KialiCache, clientFactory
 			return
 		}
 
-		// Determine whether Ambient Mesh is enabled in any accessible cluster
-		saClients := clientFactory.GetSAClients()
-		accessibleClusters := make([]string, 0, len(saClients))
-		for clusterName := range saClients {
-			accessibleClusters = append(accessibleClusters, clusterName)
-		}
-		ambientEnabled := kialiCache.IsAmbientEnabledInAnyCluster(accessibleClusters)
+		ambientEnabled := kialiCache.IsAmbientEnabledInAnyCluster(accessibleClusterNames(clientFactory))
 
 		category := r.URL.Query().Get("category")
 		catalog := prompts.Catalog()


### PR DESCRIPTION
## Summary

Suggested fixes from the review of [kiali/kiali#9989](https://github.com/kiali/kiali/pull/9989).

- **Fix ztunnel captured-service matching**: match `namespace/hostname` refs from real ztunnel dumps (e.g. `bookinfo/details.bookinfo.svc.cluster.local`), not just short service names
- **Deduplicate ambient cluster gating**: extract `accessibleClusterNames()` helper used by `ChatMCP` and `ChatPrompts`
- **Add `Execute`-level tests** for `analyze_ambient_policies` (mutual exclusivity, auto-discovery, per-namespace error handling)
- **Document `namespace` alias** in `list_or_get_resources` tool schema and update provider tests
- **Remove unused `GetBoolArg`** helper added in #9989
- **Rename `isHTTPortTLS`** to `hasHTTPOrTLS` for clarity

## Test plan

- [x] `go test ./ai/mcp/analyze_ambient_policies/...`
- [x] `go test ./ai/mcp/list_or_get_resources/... -run 'Ambient|Ztunnel'`
- [x] `go test ./ai/providers/... -run ListOrGetResources`


Made with [Cursor](https://cursor.com)