### PR TITLE
Gate KIA1317 on Ambient namespaces

### DIFF
--- a/business/checkers/ambient/ambient_workload_checker.go
+++ b/business/checkers/ambient/ambient_workload_checker.go
@@ -131,6 +131,10 @@ func (awc AmbientWorkloadChecker) hasSidecarInAmbientNamespace() bool {
 }
 
 func (awc AmbientWorkloadChecker) hasAuthPolicyAndNoWaypoint() bool {
+	// KIA1317 is Ambient-only: in sidecar mode L7 AuthPolicies apply via selectors without a waypoint.
+	if !awc.namespaces.IsNamespaceAmbient(awc.workload.Namespace, awc.cluster) {
+		return false
+	}
 	if awc.workload.IsWaypoint() || awc.workload.IsGateway() {
 		return false
 	}

--- a/business/checkers/ambient/ambient_workload_checker_test.go
+++ b/business/checkers/ambient/ambient_workload_checker_test.go
@@ -246,7 +246,7 @@ func TestWorkloadHasAuthPolicyAndNoWaypoint(t *testing.T) {
 		conf,
 		workload,
 		ns1,
-		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{}}},
+		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{}, IsAmbient: true}},
 		[]*security_v1.AuthorizationPolicy{l7Policy},
 		nil,
 	).Check()
@@ -254,6 +254,33 @@ func TestWorkloadHasAuthPolicyAndNoWaypoint(t *testing.T) {
 	assert.NotEmpty(vals)
 	assert.False(valid)
 	assert.NoError(validations.ConfirmIstioCheckMessage("workload.ambient.authpolicybutnowaypoint", vals[0]))
+}
+
+func TestWorkloadHasAuthPolicyAndNoWaypoint_NonAmbientNamespace_NoWarning(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	// Sidecar / non-Ambient namespaces must not get KIA1317 for normal L7 AuthPolicies.
+	workload := data.CreateWorkload(ns1, "reviews-v1", map[string]string{"app": "reviews"})
+	workload.WaypointWorkloads = make([]models.WorkloadReferenceInfo, 0)
+	workload.IstioSidecar = true
+	l7Policy := data.CreateAuthorizationPolicy([]string{"bookinfo"}, []string{"GET"}, []string{"reviews"}, map[string]string{"app": "reviews"})
+	l7Policy.Namespace = ns1
+
+	vals, valid := NewAmbientWorkloadChecker(
+		conf.KubernetesConfig.ClusterName,
+		conf,
+		workload,
+		ns1,
+		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{"istio-injection": "enabled"}, IsAmbient: false}},
+		[]*security_v1.AuthorizationPolicy{l7Policy},
+		nil,
+	).Check()
+
+	assert.Empty(vals)
+	assert.True(valid)
 }
 
 func TestWorkloadHasL7AuthPolicyForOtherWorkload_NoWarning(t *testing.T) {
@@ -273,7 +300,7 @@ func TestWorkloadHasL7AuthPolicyForOtherWorkload_NoWarning(t *testing.T) {
 		conf,
 		workload,
 		ns1,
-		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{}}},
+		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{}, IsAmbient: true}},
 		[]*security_v1.AuthorizationPolicy{l7Policy},
 		nil,
 	).Check()
@@ -298,7 +325,7 @@ func TestWorkloadHasL7AuthPolicyTargetRefsService_WarnsMatchedWorkload(t *testin
 		conf,
 		workload,
 		ns1,
-		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{}}},
+		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{}, IsAmbient: true}},
 		[]*security_v1.AuthorizationPolicy{l7Policy},
 		services,
 	).Check()
@@ -324,7 +351,7 @@ func TestWorkloadHasL7AuthPolicyTargetRefsService_NoWarningForOtherWorkload(t *t
 		conf,
 		workload,
 		ns1,
-		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{}}},
+		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{}, IsAmbient: true}},
 		[]*security_v1.AuthorizationPolicy{l7Policy},
 		services,
 	).Check()


### PR DESCRIPTION
## Summary
- Skip KIA1317 (`hasAuthPolicyAndNoWaypoint`) when the workload namespace is not Ambient
- Add unit test for non-Ambient / sidecar regression

Meant to land into [kiali/kiali#10076](https://github.com/kiali/kiali/pull/10076) (`issue7900`). In sidecar mode, L7 AuthPolicies with selectors are valid and must not warn about missing waypoints.

Repro for the bug (sidecar bookinfo): apply AuthPolicy `kia1317-reviews-l7-deny-get` selecting `app: reviews` → `reviews-v*` show KIA1317 incorrectly.

## Test plan
- [x] `go test ./business/checkers/ambient/ -run 'AuthPolicy|NoWaypoint'`
- [ ] Sidecar bookinfo + `kia1317-reviews-l7-deny-get` → no KIA1317 on reviews workloads
- [ ] Ambient bookinfo without enrollment + same AP → KIA1317 still shown


Made with [Cursor](https://cursor.com)