### PR TITLE
Fix sidecar ambient flake wait to match CI traffic

### DIFF
--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -138,8 +138,7 @@ const waitForBookinfoWaypointTrafficGeneratedInGraph = (
 };
 
 // Cross-ns curl clients produce 4 HTTP edges (client->service->workload x2). Ambient TCP
-// can add more, but CI often plateaus below a full 8-edge graph (see #10105). Wait for the
-// stable HTTP traffic plus at least some ambient TCP before asserting.
+// adds more for a full 8-edge graph. Wait for HTTP readiness and the full edge count.
 const waitForSidecarAmbientTrafficGeneratedInGraph = (
   maxRetries = 30,
   retryCount = 0,
@@ -148,7 +147,7 @@ const waitForSidecarAmbientTrafficGeneratedInGraph = (
 ): void => {
   const targetNamespace = 'test-ambient,test-sidecar';
   const minHttpEdges = 4;
-  const minTotalEdges = 6;
+  const minTotalEdges = 8;
 
   if (retryCount >= maxRetries) {
     throw new Error(

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -77,7 +77,7 @@ const waitForBookinfoWaypointTrafficGeneratedInGraph = (
   lastEdgeCount = -1
 ): void => {
   let totalEdges = 9;
-  if (ambientTraffic === 'waypoint' || ambientTraffic === 'total') {
+  if (ambientTraffic === 'waypoint') {
     totalEdges = 8;
   }
 
@@ -134,6 +134,67 @@ const waitForBookinfoWaypointTrafficGeneratedInGraph = (
         );
       });
     }
+  });
+};
+
+// Cross-ns curl clients produce 4 HTTP edges (client->service->workload x2). Ambient TCP
+// can add more, but CI often plateaus below a full 8-edge graph (see #10105). Wait for the
+// stable HTTP traffic plus at least some ambient TCP before asserting.
+const waitForSidecarAmbientTrafficGeneratedInGraph = (
+  maxRetries = 30,
+  retryCount = 0,
+  lastEdgeCount = -1,
+  lastHttpEdgeCount = -1
+): void => {
+  const targetNamespace = 'test-ambient,test-sidecar';
+  const minHttpEdges = 4;
+  const minTotalEdges = 6;
+
+  if (retryCount >= maxRetries) {
+    throw new Error(
+      `Condition not met after ${maxRetries} retries (waitForSidecarAmbientTrafficGeneratedInGraph, namespace=${targetNamespace}, lastEdgeCount=${lastEdgeCount}, lastHttpEdgeCount=${lastHttpEdgeCount}, expectedHttp>=${minHttpEdges}, expectedTotal>=${minTotalEdges}, baseUrl=${Cypress.config(
+        'baseUrl'
+      )})`
+    );
+  }
+
+  cy.request({
+    method: 'GET',
+    url: `${Cypress.config('baseUrl')}/api/namespaces/graph`,
+    qs: {
+      duration: '300s',
+      graphType: 'versionedApp',
+      includeIdleEdges: false,
+      injectServiceNodes: true,
+      boxBy: 'cluster,namespace,app',
+      waypoints: false,
+      ambientTraffic: 'total',
+      appenders: 'deadNode,istio,serviceEntry,meshCheck,workloadEntry,health,ambient',
+      rateGrpc: 'requests',
+      rateHttp: 'requests',
+      rateTcp: 'sent',
+      namespaces: targetNamespace
+    }
+  }).then(response => {
+    expect(response.status).to.equal(200);
+    const edges = response.body.elements?.edges ?? [];
+    const edgeCount = edges.length;
+    const httpEdgeCount = edges.filter((e: { data?: { protocol?: string } }) => e.data?.protocol === 'http').length;
+
+    if (httpEdgeCount >= minHttpEdges && edgeCount >= minTotalEdges) {
+      return;
+    }
+
+    if (retryCount === 0 || retryCount % 5 === 0) {
+      Cypress.log({
+        name: 'waitForSidecarAmbientTraffic',
+        message: `retry=${retryCount}/${maxRetries} edges=${edgeCount} httpEdges=${httpEdgeCount} expectedHttp>=${minHttpEdges} expectedTotal>=${minTotalEdges} targetNamespace=${targetNamespace}`
+      });
+    }
+
+    return cy.wait(10000).then(() => {
+      return waitForSidecarAmbientTrafficGeneratedInGraph(maxRetries, retryCount + 1, edgeCount, httpEdgeCount);
+    });
   });
 };
 
@@ -294,8 +355,8 @@ const waitForHealthyWaypoint = (name: string, namespace: string, cluster?: strin
         responseBody === undefined
           ? 'undefined'
           : typeof responseBody === 'string'
-            ? responseBody
-            : JSON.stringify(responseBody);
+          ? responseBody
+          : JSON.stringify(responseBody);
       const responseBodyShort = responseBodyStr.length > 800 ? `${responseBodyStr.slice(0, 800)}...` : responseBodyStr;
 
       const workload = responseBody;
@@ -435,7 +496,7 @@ Then('the graph page has enough data for L7 in the {string} namespace', (namespa
 });
 
 Then('the graph page has enough data for sidecar ambient traffic', () => {
-  waitForBookinfoWaypointTrafficGeneratedInGraph('test-ambient,test-sidecar', 'total', 12);
+  waitForSidecarAmbientTrafficGeneratedInGraph();
 });
 
 Then('the {string} tracing data is ready in the {string} namespace', (workload: string, namespace: string) => {
@@ -566,8 +627,7 @@ Then('the link for the waypoint {string} should redirect to a valid workload det
     .contains('a,button', waypoint)
     .then($el => {
       // In kiosk mode KialiLink renders a button with data-href; in normal mode it renders an anchor.
-      const target =
-        $el.prop('tagName')?.toLowerCase() === 'a' ? ($el.attr('href') ?? '') : ($el.attr('data-href') ?? '');
+      const target = $el.prop('tagName')?.toLowerCase() === 'a' ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
       expect(target, 'standalone Kiali waypoint link target').to.include(`/workloads/${waypoint}`);
       if (isOSSMC) {
         // Even if the button exist, the click event doesn't work (Even with force).
@@ -588,7 +648,7 @@ Then('the waypoint link points to the {string} cluster', (cluster: string) => {
     const $el = $waypointLink.filter('a, button').add($waypointLink.find('a, button')).first();
     expect($el.length, 'waypoint link element').to.be.greaterThan(0);
 
-    const target = $el.is('a') ? ($el.attr('href') ?? '') : ($el.attr('data-href') ?? '');
+    const target = $el.is('a') ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
     expect(target).to.include(`clusterName=${cluster}`);
   });
 });

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -408,8 +408,7 @@ Feature: Kiali Waypoint related features
     And user "closes" traffic menu
     Then user "opens" display menu
     And user "enables" "security" option
-    # Ambient TCP edges are racy in CI (often 6 instead of 8); HTTP cross-ns traffic is stable at 4.
-    Then 6 edges appear in the graph
+    Then 8 edges appear in the graph
     Then security "appears" in the graph
     And user "closes" display menu
     Then user "opens" traffic menu

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -408,7 +408,8 @@ Feature: Kiali Waypoint related features
     And user "closes" traffic menu
     Then user "opens" display menu
     And user "enables" "security" option
-    Then 8 edges appear in the graph
+    # Ambient TCP edges are racy in CI (often 6 instead of 8); HTTP cross-ns traffic is stable at 4.
+    Then 6 edges appear in the graph
     Then security "appears" in the graph
     And user "closes" display menu
     Then user "opens" traffic menu


### PR DESCRIPTION
### Describe the change

Follow-up to https://github.com/kiali/kiali/pull/10110.

CI on that PR still fails with `lastEdgeCount=6, expected>=8` after 12 retries ([example](https://github.com/kiali/kiali/actions/runs/30088822511/job/89908841924)).

Changes:
- Replace the shared helper call (`total`, maxRetries=12) with a dedicated wait that requires **HTTP edges >= 4** (stable cross-ns curl traffic) and **total edges >= 8**
- Use the default **30** retries instead of 12
- Keep the UI assertion at **8** edges

### Steps to test the PR

1. Merge/check out this branch on top of `issue10105`
2. Run ambient Cypress suite, or specifically the `[Traffic] Sidecar Ambient traffic` scenario

### Automation testing

- `frontend/cypress/integration/featureFiles/waypoint.feature` — `[Traffic] Sidecar Ambient traffic`
- `frontend/cypress/integration/common/waypoint.ts` — `waitForSidecarAmbientTrafficGeneratedInGraph`

### Issue reference

Ref #10105