### PR TITLE
Fix HTTP edge protocol path in ambient wait

### DIFF
--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -178,7 +178,10 @@ const waitForSidecarAmbientTrafficGeneratedInGraph = (
     expect(response.status).to.equal(200);
     const edges = response.body.elements?.edges ?? [];
     const edgeCount = edges.length;
-    const httpEdgeCount = edges.filter((e: { data?: { protocol?: string } }) => e.data?.protocol === 'http').length;
+    // Graph API puts protocol under data.traffic; UI decorates data.protocol later.
+    const httpEdgeCount = edges.filter(
+      (e: { data?: { traffic?: { protocol?: string } } }) => e.data?.traffic?.protocol === 'http'
+    ).length;
 
     if (httpEdgeCount >= minHttpEdges && edgeCount >= minTotalEdges) {
       return;


### PR DESCRIPTION
### Describe the change

Latest CI on https://github.com/kiali/kiali/pull/10110 failed with:

```
lastEdgeCount=8, lastHttpEdgeCount=0, expectedHttp>=4, expectedTotal>=8
```

Total edges were already ready; the HTTP check always returned 0 because the graph API puts protocol under `data.traffic.protocol` (UI decorates `data.protocol` later).

### Steps to test the PR

1. Merge onto `issue10105`
2. Re-run ambient Cypress / `[Traffic] Sidecar Ambient traffic`

### Automation testing

- `waitForSidecarAmbientTrafficGeneratedInGraph` in `frontend/cypress/integration/common/waypoint.ts`

### Issue reference

Ref #10105

Made with [Cursor](https://cursor.com)